### PR TITLE
Enable `beta` as version parameter

### DIFF
--- a/lib/microsoft/graph.rb
+++ b/lib/microsoft/graph.rb
@@ -12,7 +12,7 @@ module Microsoft
     BODY_METHODS = %w[POST PUT PATCH].freeze
     ALLOWED_METHODS = [*BODY_METHODS, "GET", "DELETE"].freeze
 
-    def initialize(token: nil, error_handler: method(:error_handler), version: "1.0")
+    def initialize(token: nil, error_handler: method(:error_handler), version: "v1.0")
       @token = token
       @parser = URI::Parser.new
       @body_formatter = Microsoft::Graph::BodyFormatter.new
@@ -39,7 +39,7 @@ module Microsoft
       method = method.upcase
       raise ArgumentError, "`#{method}` is not a valid HTTP method." unless ALLOWED_METHODS.include?(method)
 
-      url = URI.join(GRAPH_HOST, @parser.escape("v#{@version}/#{endpoint.gsub(%r{^/}, "")}"))
+      url = URI.join(GRAPH_HOST, @parser.escape("#{@version}/#{endpoint.gsub(%r{^/}, "")}"))
       headers = headers.merge(
         Authorization: "Bearer #{token}",
         Accept: "application/json"

--- a/lib/microsoft/graph.rb
+++ b/lib/microsoft/graph.rb
@@ -12,6 +12,8 @@ module Microsoft
     BODY_METHODS = %w[POST PUT PATCH].freeze
     ALLOWED_METHODS = [*BODY_METHODS, "GET", "DELETE"].freeze
 
+    attr_reader :last_response
+
     def initialize(token: nil, error_handler: method(:error_handler), version: "v1.0")
       @token = token
       @parser = URI::Parser.new
@@ -54,6 +56,7 @@ module Microsoft
         body: @body_formatter.call(body, method: method).to_json,
         parser: InstanceParser
       )
+      @last_response = response
 
       case response.code
       when 200...400


### PR DESCRIPTION
Instead of hardcoding the `v` in `v#{version}` move it into the `version` parameter to enable initializing a new graph client with the `beta` version to access the Microsoft Graph [beta](https://docs.microsoft.com/en-au/graph/api/overview?view=graph-rest-beta&preserve-view=true) endpoint.