### PR TITLE
Support requests where the body may not be JSON

### DIFF
--- a/lib/microsoft/graph.rb
+++ b/lib/microsoft/graph.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "httparty"
+require "ostruct"
 require "securerandom"
 require_relative "graph/version"
 require_relative "graph/batch"
@@ -51,7 +52,7 @@ module Microsoft
         url,
         headers: headers,
         query: params,
-        body: @body_formatter.call(body, method: method).to_json,
+        body: @body_formatter.call(body, method: method),
         parser: InstanceParser
       )
 

--- a/lib/microsoft/graph/body_formatter.rb
+++ b/lib/microsoft/graph/body_formatter.rb
@@ -6,8 +6,9 @@ module Microsoft
       def call(body, method:)
         return nil unless Microsoft::Graph::BODY_METHODS.include?(method)
         return nil unless body
+        return body unless body.is_a?(Hash)
 
-        body.transform_keys(&method(:camelize))
+        body.transform_keys(&method(:camelize)).to_json
       end
 
       private


### PR DESCRIPTION
Some requests, such as uploading a file to OneDrive, require the contents to be passed as the body of the request. This content is not a hash, but the client currently expects a hash to be converted to JSON.

This check's the body's type before calling `transform_keys`, and moves the `to_json` call to the body formatter.

Additionally, I've added a missing require for `ostruct`.